### PR TITLE
New functions that help scripts find valid pianos

### DIFF
--- a/Piano/script.lua
+++ b/Piano/script.lua
@@ -85,32 +85,32 @@ end
 
 
 function getPianoIDs()
-    local pianoIDs = {}
-    for id, _ in pairs(pianos) do
-        table.insert(pianoIDs, id)
-    end
-    return pianoIDs
+  local pianoIDs = {}
+  for id, _ in pairs(pianos) do
+    table.insert(pianoIDs, id)
+  end
+  return pianoIDs
 end
 
 function getPianoPositions()
-    local PianoPositions = {}
-    for _, piano in pairs(pianos) do
-        table.insert(PianoPositions, piano.pos:copy())
-    end
-    return PianoPositions
+  local PianoPositions = {}
+  for _, piano in pairs(pianos) do
+    table.insert(PianoPositions, piano.pos:copy())
+  end
+  return PianoPositions
 end
 
 function getNearestPianoID(testPosition)
-    local nearestPianoID
-    local nearestPianoDistSquared
-    for id, piano in pairs(pianos) do
-        local newDistSquared = piano.pos:copy():sub(testPosition):lengthSquared()
-        if not nearestPianoID or newDistSquared < nearestPianoDistSquared then 
-            nearestPianoID = id
-            nearestPianoDistSquared = newDistSquared
-        end
+  local nearestPianoID
+  local nearestPianoDistSquared
+  for id, piano in pairs(pianos) do
+    local newDistSquared = piano.pos:copy():sub(testPosition):lengthSquared()
+    if not nearestPianoID or newDistSquared < nearestPianoDistSquared then 
+      nearestPianoID = id
+      nearestPianoDistSquared = newDistSquared
     end
-    return nearestPianoID, (nearestPianoID and pianos[nearestPianoID].pos:copy() or nil)
+  end
+  return nearestPianoID, (nearestPianoID and pianos[nearestPianoID].pos:copy() or nil)
 end
 
 -- stores important functions so that other avatars can access them through avatarVars() in the world API

--- a/Piano/script.lua
+++ b/Piano/script.lua
@@ -103,10 +103,8 @@ end
 function getNearestPianoID(testPosition)
     local nearestPianoID
     local nearestPianoDistSquared
-    print("---")
     for id, piano in pairs(pianos) do
         local newDistSquared = piano.pos:copy():sub(testPosition):lengthSquared()
-        print("testing",id,testPosition, piano.pos:copy(), piano.pos:copy():sub(testPosition), newDistSquared)
         if not nearestPianoID or newDistSquared < nearestPianoDistSquared then 
             nearestPianoID = id
             nearestPianoDistSquared = newDistSquared

--- a/Piano/script.lua
+++ b/Piano/script.lua
@@ -112,7 +112,7 @@ function getNearestPianoID(testPosition)
             nearestPianoDistSquared = newDistSquared
         end
     end
-    return nearestPianoID, pianos[nearestPianoID].pos:copy()
+    return nearestPianoID, (nearestPianoID and pianos[nearestPianoID].pos:copy() or nil)
 end
 
 -- stores important functions so that other avatars can access them through avatarVars() in the world API

--- a/Piano/script.lua
+++ b/Piano/script.lua
@@ -83,11 +83,46 @@ function playSound(keyID,notePos,noteVolume)
   sounds:playSound(keyPitches[keyID][2],notePos,noteVolume,keyPitches[keyID][1])
 end
 
+
+function getPianoIDs()
+    local pianoIDs = {}
+    for id, _ in pairs(pianos) do
+        table.insert(pianoIDs, id)
+    end
+    return pianoIDs
+end
+
+function getPianoPositions()
+    local PianoPositions = {}
+    for _, piano in pairs(pianos) do
+        table.insert(PianoPositions, piano.pos:copy())
+    end
+    return PianoPositions
+end
+
+function getNearestPianoID(testPosition)
+    local nearestPianoID
+    local nearestPianoDistSquared
+    print("---")
+    for id, piano in pairs(pianos) do
+        local newDistSquared = piano.pos:copy():sub(testPosition):lengthSquared()
+        print("testing",id,testPosition, piano.pos:copy(), piano.pos:copy():sub(testPosition), newDistSquared)
+        if not nearestPianoID or newDistSquared < nearestPianoDistSquared then 
+            nearestPianoID = id
+            nearestPianoDistSquared = newDistSquared
+        end
+    end
+    return nearestPianoID, pianos[nearestPianoID].pos:copy()
+end
+
 -- stores important functions so that other avatars can access them through avatarVars() in the world API
 avatar:store("playNote",playNote)
 avatar:store("playSound",playSound)
 avatar:store("validPos", function(pianoID) return pianos[pianoID] ~= nil end)
 avatar:store("getPlayingKeys", function(pianoID) return pianos[pianoID] ~= nil and pianos[pianoID].playingKeys or nil end)
+avatar:store("getPianoIDs", getPianoIDs)
+avatar:store("getPianoPositions", getPianoPositions)
+avatar:store("getNearestPianoID", getNearestPianoID)
 
 -- the tick function >~>
 function events.world_tick()

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The `playNote()` function just plays a note on the piano when run. It contains t
 - `notePos` is a vec3 containing the world coordinates the note should play at. If left empty, it will just play at. You can simply ignore this and it will play at the player head coordinates. This is rarely useful, but if you want you can use the piano as a piano sample library (assuming you have it loaded), and play piano sounds anywhere in the world.
 - `noteVolume` is a number that sets the volume of the sound. If left empty, it defaults to 2. Note that volumes higher than 1 don't increase the loudness of the sound, but instead multiplies the audable radious of the sound. (1 = 16 blocks, 2 = 32 blocks, etc.)
 
-<details><summary>Click to see more functions included in the API.</summary>
+<details><summary>Click to see more functions included in the library.</summary>
 
 ### playSound()
 ```lua

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ piano_lib  =  world.avatarVars()["943218fd-5bbc-4015-bf7f-9da4f37bac59"]
 Once this is created, you'll be able to access the following functions:
 ### playNote()
 ```lua
-piano_lib.playNote(pianoID, keyID, doesPlaySound, notePos)
+piano_lib.playNote(pianoID, keyID, doesPlaySound, notePos, noteVolume)
 ```
 The `playNote()` function just plays a note on the piano when run. It contains the following:
 - `pianoID` is a string containing the ID of the selected piano. E.g. `"{1, 65, -102}"`. The ID is determined by the player head coordinates. To easily grab the ID, run `tostring(pos)` where `pos` is a vec3 of the selected piano head position.
 - `keyID` is a string containing the ID of the note that should play. E.g. `"C2"`,`"F#3"`,`"A0"` This is just standard notation formatting of note as a letter, followed by octave as a number.
 - `doesPlaySound` is a boolean which determines if a sound will play when the note is pressed. This exists to make the implementation for holding notes simple. Just keep this as `true`.
 - `notePos` is a vec3 containing the world coordinates the note should play at. If left empty, it will just play at. You can simply ignore this and it will play at the player head coordinates. This is rarely useful, but if you want you can use the piano as a piano sample library (assuming you have it loaded), and play piano sounds anywhere in the world.
+- `noteVolume` is a number that sets the volume of the sound. If left empty, it defaults to 2. Note that volumes higher than 1 don't increase the loudness of the sound, but instead multiplies the audable radious of the sound. (1 = 16 blocks, 2 = 32 blocks, etc.)
 
 ## Planned Features
 Remind me to make these things please >w>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,69 @@ The `playNote()` function just plays a note on the piano when run. It contains t
 - `notePos` is a vec3 containing the world coordinates the note should play at. If left empty, it will just play at. You can simply ignore this and it will play at the player head coordinates. This is rarely useful, but if you want you can use the piano as a piano sample library (assuming you have it loaded), and play piano sounds anywhere in the world.
 - `noteVolume` is a number that sets the volume of the sound. If left empty, it defaults to 2. Note that volumes higher than 1 don't increase the loudness of the sound, but instead multiplies the audable radious of the sound. (1 = 16 blocks, 2 = 32 blocks, etc.)
 
+<details><summary>Click to see more functions included in the API.</summary>
+
+### playSound()
+```lua
+piano_lib.playSound(keyID, notePos, noteVolume)
+```
+`playSound()` allows you to play the sounds of the piano from any position without requiring a real piano. 
+
+Paramiters are the same as in `playNote()`, but without `pianoID` and `doesPlaySound`
+
+### validPos()
+```lua
+local posIsValid = piano_lib.validPos(pianoID)
+```
+`validPos()` lets you test a pianoID to see if it is a valid piano before you interact with it. 
+- Returns a boolean
+- `pianoID` is a string containing the ID of the selected piano. See `playNote()` for more info. 
+
+### getPlayingKeys()
+```lua
+local playingKeys = piano_lib.getPlayingKeys(pianoID)
+```
+`getPlayingKeys()` gives you a table of keys that are currently being played on the given piano. 
+- Returns a table indexed by `keyID` and storing the world time of when the key was pressed. (See `world.getTime()` in the Figura docs.)
+- `pianoID` is a string containing the ID of the selected piano. See `playNote()` for more info. 
+
+### getPianoIDs()
+```lua
+local pianoIDs = piano_lib.getPianoIDs()
+```
+`getPianoIDs()` returns the IDs of all known pianos in a list. The list is indexed by integers starting at 1 so is sutable for `for _,_ in ipairs()` loops, but they are not in any particular order.
+
+### getPianoPositions()
+```lua
+local pianoPositions = piano_lib.getPianoPositions()
+```
+`getPianoPositions()` returns the positions of all known pianos in a list. The list is indexed by integers starting at 1 so is sutable for `for _,_ in ipairs()` loops, but they are not in any particular order. 
+
+You will still need to convert a position back to an ID using `tostring()` if you want to use the piano at that position.
+
+### getNearestPianoID()
+```lua
+local nearestPianoID, nearestPianoPosition = piano_lib.getNearestPianoID(testPosition)
+```
+`getNearestPianoID()` returns the ID (and position) of the piano nearest to `testPosition`. 
+- Returns a string and a vec3 representing the nearest piano's `pianoID` and position.
+- `testPosition` is a vec3
+
+This function allows for handy shorthands like 
+
+```lua
+local nearestPianoID = piano_lib.getNearestPianoID(player:getPos())
+piano_lib.playNote(nearestPianoID, "C4", true)
+```
+
+to quickly control the nearest piano, without checking all the pianos or all of the nearby blocks for a valid piano. 
+
+Note that this function simply loops through all the known pianos and compares their reletive distances. This can be an expensive opperation in worlds with lots of pianos. Furthermore, pianos only become "known" once they've been seen/rendered by the viewer. There may be cases where you are physicaly near a piano that isn't returned by `getNearestPianoID()`. EG: The piano is behind a wall.
+
+
+</details>
+
+
 ## Planned Features
 Remind me to make these things please >w>
 - Height customisation using a `setHeight()` function

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ piano_lib.playSound(keyID, notePos, noteVolume)
 ```
 `playSound()` allows you to play the sounds of the piano from any position without requiring a real piano. 
 
-Paramiters are the same as in `playNote()`, but without `pianoID` and `doesPlaySound`
+Parameters are the same as in `playNote()`, but without `pianoID` and `doesPlaySound`
 
 ### validPos()
 ```lua
@@ -60,13 +60,13 @@ local playingKeys = piano_lib.getPlayingKeys(pianoID)
 ```lua
 local pianoIDs = piano_lib.getPianoIDs()
 ```
-`getPianoIDs()` returns the IDs of all known pianos in a list. The list is indexed by integers starting at 1 so is sutable for `for _,_ in ipairs()` loops, but they are not in any particular order.
+`getPianoIDs()` returns the IDs of all known pianos in a list. The list is indexed by integers starting at 1, so it is suitable for `for _,_ in ipairs()` loops, but they are not in any particular order.
 
 ### getPianoPositions()
 ```lua
 local pianoPositions = piano_lib.getPianoPositions()
 ```
-`getPianoPositions()` returns the positions of all known pianos in a list. The list is indexed by integers starting at 1 so is sutable for `for _,_ in ipairs()` loops, but they are not in any particular order. 
+`getPianoPositions()` returns the positions of all known pianos in a list. The list is indexed by integers starting at 1, so it is suitable for `for _,_ in ipairs()` loops, but they are not in any particular order. 
 
 You will still need to convert a position back to an ID using `tostring()` if you want to use the piano at that position.
 
@@ -78,7 +78,7 @@ local nearestPianoID, nearestPianoPosition = piano_lib.getNearestPianoID(testPos
 - Returns a string and a vec3 representing the nearest piano's `pianoID` and position.
 - `testPosition` is a vec3
 
-This function allows for handy shorthands like 
+This function allows for useful shorthands like 
 
 ```lua
 local nearestPianoID = piano_lib.getNearestPianoID(player:getPos())
@@ -87,7 +87,7 @@ piano_lib.playNote(nearestPianoID, "C4", true)
 
 to quickly control the nearest piano, without checking all the pianos or all of the nearby blocks for a valid piano. 
 
-Note that this function simply loops through all the known pianos and compares their reletive distances. This can be an expensive opperation in worlds with lots of pianos. Furthermore, pianos only become "known" once they've been seen/rendered by the viewer. There may be cases where you are physicaly near a piano that isn't returned by `getNearestPianoID()`. EG: The piano is behind a wall.
+Note that this function simply loops through all the known pianos and compares their relative distances. This can be an expensive operation in worlds with lots of pianos. Furthermore, pianos only become "known" once they've been seen/rendered by the viewer. There may be cases where you are physically near a piano that isn't returned by `getNearestPianoID()`. EG: The piano is behind a wall.
 
 
 </details>


### PR DESCRIPTION
Usually it's pretty simple to get a raycast from a player or test just a few blocks to figure out what piano a player wants to control. But if a script just wants to get any piano, things are a bit more difficult. 

These functions make it trivial for a script to get any piano, or find the nearest piano. 

```
/figura run piano_lib = world.avatarVars()[ "piano_lib_uuid" ]; piano_lib.playNote(piano_lib.getNearestPianoID(player:getPos()), "C4", true, nil, 1);
```

One limitation is that these functions draw from the pianos table, which is only populated by pianos that the player has seen/rendered. A piano that is physically close, but behind a wall might not be returned by these functions. (The other functions like `validPos()` all suffer from the same issue, it just might be more obvious with these new ones.)

(While I was here, I also updated the README to include documentation for all of the library functions)